### PR TITLE
Fix/reynolds friction pipes #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+* **Hydraulic pressure calculation refactor:** Solved an issue where Reynolds number and friction factor were not consistently set for all pipe types, particularly `LagrangianPipe`. The `compute_dp_pipe_net` and `compute_dp_valve_net` functions now accept a `mask` parameter, processing and returning results only for the specified components. Consequently, their `dp` and `dp_der` outputs now have a dimensionality corresponding to the masked subset, rather than the entire network. The `compute_dp` function has been updated to correctly pass component masks to these vector functions and integrate their masked outputs into the overall pressure arrays. (See #6)
 * Fixed a bug in `pipe_test` related to local data reading.
 * **Heat exchanger model:** Refined the heat exchanger model's behavior (`compute_hx_temp` and related functions) for consistent energy interpretation in dynamic simulations. The `delta_q` parameter and return values are now uniformly treated as Watt-hours (Wh). A new `stepsize` parameter (in seconds), defaulting to `3600.0`s for backward compatibility, was added for internal energy-to-power conversions. Users with non-hourly `stepsize` in dynamic simulations should now explicitly pass their `stepsize` to consumers and producers. (See #5)
 * Changed the sign of `LagrangianPipe`'s `delta_q` to be negative when heat is lost.

--- a/pydhn/solving/pressure.py
+++ b/pydhn/solving/pressure.py
@@ -181,9 +181,9 @@ def compute_dp(
                 has_vector = True
         if has_vector:
             foo = COMPONENT_FUNCTIONS_DICT[component]["delta_p"]
-            out_1, out_2 = foo(net, fluid, ts_id=ts_id)
-            dp[component_mask] = out_1[component_mask]
-            dp_der[component_mask] = out_2[component_mask]
+            out_1, out_2 = foo(net, fluid, mask=component_mask, ts_id=ts_id)
+            dp[component_mask] = out_1
+            dp_der[component_mask] = out_2
         # Otherwise, compute the value for each component of that type
         # separately
         else:


### PR DESCRIPTION
### **Fix: Consistent Reynolds number and friction factor for all pipe types**

This PR addresses issue #6 by ensuring the `reynolds` and `friction_factor` attributes are consistently set for all relevant pipe classes, including `LagrangianPipe`, within the hydraulic simulation.

#### Key Changes:

* **Masked Processing in Vector Functions:**
    * `compute_dp_pipe_net` and `compute_dp_valve_net` now accept a `mask` parameter.
    * These functions now only retrieve attributes (like `mass_flow`, `diameter`, `kv`) for the components specified by the `mask`.
    * The `reynolds` and `friction_factor` attributes are now set using this mask, guaranteeing they're applied to the intended pipes.
* **Dimensionality Alignment in `compute_dp`:**
    * The `compute_dp` function has been updated to pass the `component_mask` to these `delta_p` vector functions.
    * The outputs (`dp` and `dp_der`) from `compute_dp_pipe_net` and `compute_dp_valve_net` now correspond in dimensionality to the masked subset of components, rather than the entire network. `compute_dp` correctly handles this by directly assigning these masked outputs to the relevant indices of its full `dp` and `dp_der` arrays.

Closes #6