### PR TITLE
fix(build-docs): Correct conf.py import order for 'autovalue'

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,8 +18,6 @@
 import os
 import sys
 
-import autovalue
-
 project = "PyDHN"
 copyright = (
     "2024, Idiap Research Institute, https://www.idiap.ch, EPFL, https://www.epfl.ch"
@@ -45,6 +43,8 @@ doctest_test_doctest_blocks = "default"
 sys.path.insert(0, os.path.abspath("../.."))
 sys.path.insert(0, os.path.abspath("../pydhn"))
 sys.path.insert(0, os.path.abspath("."))
+
+import autovalue  # noqa: E402
 
 
 def skip(app, what, name, obj, would_skip, options):


### PR DESCRIPTION
This PR resolves a `ModuleNotFoundError: No module named 'autovalue'` that was occurring during documentation builds on the `main` branch.

The `import autovalue` statement in `docs/source/conf.py` was being executed before its path was added to `sys.path`. This fix moves the import statement after the `sys.path` modifications, and adds a `noqa: E402` comment to resolves conflicts with `flake8`.
